### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/public/quickadmin/js/vue.js
+++ b/public/quickadmin/js/vue.js
@@ -3475,30 +3475,35 @@
         }
 
         var frag = document.createDocumentFragment();
-        var tagMatch = templateString.match(tagRE$1);
-        var entityMatch = entityRE.test(templateString);
-
-        if (!tagMatch && !entityMatch) {
-            // text only, return a single text node.
+        // If raw is true, always treat as plain text, never interpret as HTML!
+        if (raw) {
             frag.appendChild(document.createTextNode(templateString));
         } else {
-            var tag = tagMatch && tagMatch[1];
-            var wrap = map[tag] || map.efault;
-            var depth = wrap[0];
-            var prefix = wrap[1];
-            var suffix = wrap[2];
-            var node = document.createElement('div');
+            var tagMatch = templateString.match(tagRE$1);
+            var entityMatch = entityRE.test(templateString);
+        
+            if (!tagMatch && !entityMatch) {
+                // text only, return a single text node.
+                frag.appendChild(document.createTextNode(templateString));
+            } else {
+                var tag = tagMatch && tagMatch[1];
+                var wrap = map[tag] || map.efault;
+                var depth = wrap[0];
+                var prefix = wrap[1];
+                var suffix = wrap[2];
+                var node = document.createElement('div');
 
-            node.innerHTML = prefix + templateString + suffix;
-            while (depth--) {
-                node = node.lastChild;
-            }
+                node.innerHTML = prefix + templateString + suffix;
+                while (depth--) {
+                    node = node.lastChild;
+                }
 
-            var child;
-            /* eslint-disable no-cond-assign */
-            while (child = node.firstChild) {
-                /* eslint-enable no-cond-assign */
-                frag.appendChild(child);
+                var child;
+                /* eslint-disable no-cond-assign */
+                while (child = node.firstChild) {
+                    /* eslint-enable no-cond-assign */
+                    frag.appendChild(child);
+                }
             }
         }
         if (!raw) {
@@ -3527,7 +3532,8 @@
         }
         // script template
         if (node.tagName === 'SCRIPT') {
-            return stringToFragment(node.textContent);
+            // Always treat script templates as text to avoid XSS
+            return stringToFragment(node.textContent, true);
         }
         // normal node, clone it to avoid mutating the original
         var clonedNode = cloneNode(node);


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/3](https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/3)

To fix the vulnerability, you need to ensure that data extracted from the DOM as text and then reinserted into `element.innerHTML` is first properly escaped. The best way is to convert text nodes into actual DOM nodes using text handling APIs, rather than treating them as HTML fragments. For the `<script>` case in `nodeToFragment`, when passing `node.textContent` to `stringToFragment`, you should prevent interpretation as HTML. In `stringToFragment`, if `raw` is set or the input is to be treated as a text node only, you should use `createTextNode` instead of `innerHTML`. For best effect and minimal disruption, this means:  
- In `nodeToFragment`, when processing `<script>` tags, call `stringToFragment(node.textContent, true)` to indicate "raw" mode, so it is handled only as text;  
- In `stringToFragment`, if `raw` is `true`, always treat the input as text (and do not use `innerHTML`).  
This way, tainted text is never directly parsed as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
