### PR TITLE
Potential fix for code scanning alert no. 4: Prototype-polluting function

### DIFF
--- a/public/quickadmin/js/vue.js
+++ b/public/quickadmin/js/vue.js
@@ -1639,6 +1639,8 @@
     function mergeData(to, from) {
         var key, toVal, fromVal;
         for (key in from) {
+            // Prevent prototype pollution
+            if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
             toVal = to[key];
             fromVal = from[key];
             if (!hasOwn(to, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/4](https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/4)

To fix the prototype pollution vulnerability in `mergeData`, we must ensure that dangerous keys like `__proto__`, `constructor`, and (optionally) `prototype` are not ever used to assign properties to the target object. The best way to do this is to add a check to skip these keys in the `mergeData` function, both at the top of the key-handling loop. This means, before doing any assignments or recursive calls, we check if `key` is one of the dangerous names and continue the loop if so. Only the `mergeData` function needs to be changed; edits to `set` are unnecessary.

**What to change:**  
- Edit file `public/quickadmin/js/vue.js`.
- Inside the `mergeData(to, from)` function, after `for (key in from) {`, insert an `if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;` before any writes or recursions are made.

No imports or new methods are needed. Only direct code edits to `mergeData` are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
