### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/public/quickadmin/js/vue.js
+++ b/public/quickadmin/js/vue.js
@@ -10,6 +10,10 @@
 }(this, function () { 'use strict';
 
     function set(obj, key, val) {
+        if (key === '__proto__' || key === 'constructor') {
+            // Prevent prototype pollution
+            return;
+        }
         if (hasOwn(obj, key)) {
             obj[key] = val;
             return;
@@ -1639,6 +1643,10 @@
     function mergeData(to, from) {
         var key, toVal, fromVal;
         for (key in from) {
+            if (key === '__proto__' || key === 'constructor') {
+                // Prevent prototype pollution
+                continue;
+            }
             toVal = to[key];
             fromVal = from[key];
             if (!hasOwn(to, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/5](https://github.com/santiagourdaneta/cybercontrol/security/code-scanning/5)

To fix this prototype pollution vulnerability, block dangerous keys like `__proto__` and `constructor` during deep object merging. When copying properties from `from` to `to` in the `mergeData` function (line 1641 onward), skip any keys that could allow modification of the object's or its parents' prototype chain. Similarly, adjust the `set` function to also refuse to set values for these keys directly.

**Detailed fix plan:**
- In `mergeData(to, from)`, line 1641, add a check inside the loop to skip keys equal to `"__proto__"` or `"constructor"`.
- In the `set` function (line 12), `set(obj, key, val)`, add a guard clause to exit early if `key === '__proto__'` or `key === 'constructor'`.
- No changes to expected application data structure or other logic.
- No new dependencies needed.

**All changes are in `public/quickadmin/js/vue.js`, applied directly to the contexts of `mergeData` and `set`.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
